### PR TITLE
unregister only if enabled

### DIFF
--- a/src/main/java/net/elytrium/velocitytools/VelocityTools.java
+++ b/src/main/java/net/elytrium/velocitytools/VelocityTools.java
@@ -148,8 +148,8 @@ public class VelocityTools {
     setRatelimiter(Ratelimiters.createWithMilliseconds(Settings.IMP.COMMANDS.RATELIMIT_DELAY));
 
     List<String> aliases = Settings.IMP.COMMANDS.HUB.ALIASES;
-    aliases.forEach(alias -> this.server.getCommandManager().unregister(alias));
     if (Settings.IMP.COMMANDS.HUB.ENABLED && !aliases.isEmpty()) {
+      aliases.forEach(alias -> this.server.getCommandManager().unregister(alias));
       this.server.getCommandManager().register(aliases.get(0), new HubCommand(this.server), aliases.toArray(new String[0]));
     }
 


### PR DESCRIPTION
Prevents Velocity Tools from unregistering hub command aliases if the hub command is not enabled.